### PR TITLE
Add QR code link support

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <title>Communication Card Generator V2.1</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js" integrity="sha512-BNaRQnYJYiPSqHHDb58B0yaPfCu+Wgds8Gp/gU33kqBtgNS4tSPHuGibyoeqMV/TJlSKda6FXzoEyYGjTe+vXA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js" integrity="sha512-Vx0s8AjtKoa6HgMHqmpYyqn1nVbWcv16O3MHuvb6jVWeItPxX2VINeodIZ6Tn6PvxI6Bfq5VnXNDP+JlYqwxFA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <style>
         /* Custom CSS */
         body { font-family: 'Inter', sans-serif; background-color: #f4f4f5; }
@@ -66,6 +67,15 @@
             margin-right: 15px;
             margin-bottom: 5px; /* Space below creator */
             font-size: 10px; color: #71717a;
+        }
+
+        .card-qr-code {
+            position: absolute;
+            bottom: 10px;
+            right: 10px;
+            width: 50px;
+            height: 50px;
+            display: none;
         }
 
         /* Input styling remains the same */
@@ -149,6 +159,10 @@
                 <input type="text" id="creatorName" name="creatorName" placeholder="e.g., Liam" class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500">
             </div>
             <div class="mb-4">
+                <label for="linkUrl" class="block text-sm font-medium text-gray-700 mb-1">Link (Optional):</label>
+                <input type="url" id="linkUrl" name="linkUrl" placeholder="https://example.com" class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500">
+            </div>
+            <div class="mb-4">
                 <label for="cardImage" class="block text-sm font-medium text-gray-700 mb-1">Image:</label>
                 <input type="file" id="cardImage" name="cardImage" accept="image/*" class="w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100">
                 <input type="hidden" id="imageDataUrl" name="imageDataUrl">
@@ -173,8 +187,9 @@
                     <div id="previewNotesText" class="card-notes-text"></div>
                 </div>
                 <div id="previewCreatorInfo" class="card-creator-info"> Card by Creator Name </div>
+                <div id="qrCodeContainer" class="card-qr-code"></div>
             </div>
-             <p class="text-xs text-gray-500 mt-2 text-center">Note: Main text in preview is directly editable.</p>
+            <p class="text-xs text-gray-500 mt-2 text-center">Note: Main text in preview is directly editable.</p>
         </div>
     </div>
 
@@ -187,6 +202,7 @@
         const mainTextInput = document.getElementById('mainText'); // Textarea
         const notesTextInput = document.getElementById('notesText');
         const creatorNameInput = document.getElementById('creatorName');
+        const linkUrlInput = document.getElementById('linkUrl');
         const cardImageInput = document.getElementById('cardImage');
         const imageDataUrlInput = document.getElementById('imageDataUrl');
         const templateSelect = document.getElementById('templateSelect');
@@ -206,6 +222,7 @@
         const previewMainText = document.getElementById('previewMainText'); // Editable Div
         const previewNotesText = document.getElementById('previewNotesText');
         const previewCreatorInfo = document.getElementById('previewCreatorInfo');
+        const qrCodeContainer = document.getElementById('qrCodeContainer');
 
         // Constants and Defaults (remain the same)
         const LOCAL_STORAGE_KEY = 'savedCommCardData';
@@ -244,7 +261,18 @@
         function autoResizeTextarea(textarea) {
             textarea.style.height = 'auto';
             textarea.style.height = (textarea.scrollHeight + 2) + 'px';
-         }
+        }
+
+        function updateQRCode() {
+            const url = linkUrlInput.value.trim();
+            qrCodeContainer.innerHTML = '';
+            if (url) {
+                new QRCode(qrCodeContainer, { text: url, width: 50, height: 50 });
+                qrCodeContainer.style.display = 'block';
+            } else {
+                qrCodeContainer.style.display = 'none';
+            }
+        }
 
         // Update Functions (Removed adjustLayout call)
         function updatePreviewFromInputs() {
@@ -265,8 +293,9 @@
                  previewArt.style.backgroundImage = 'none';
                  previewArt.style.backgroundColor = '#e4e4e7';
             }
+            updateQRCode();
             // adjustLayout(); // No longer needed
-         }
+        }
 
          // Event Listeners (Removed adjustLayout calls)
 
@@ -276,6 +305,7 @@
         cardSubtitleInput.addEventListener('input', () => { previewSubtitle.textContent = cardSubtitleInput.value || 'Subtitle / Key Info'; /* adjustLayout(); */ });
         notesTextInput.addEventListener('input', () => { previewNotesText.textContent = notesTextInput.value; });
         creatorNameInput.addEventListener('input', () => { previewCreatorInfo.textContent = creatorNameInput.value ? `Card by ${creatorNameInput.value}` : ''; });
+        linkUrlInput.addEventListener('input', updateQRCode);
 
         mainTextInput.addEventListener('input', () => { autoResizeTextarea(mainTextInput); const htmlContent = mainTextInput.value.replace(/\n/g, '<br>'); if (document.activeElement !== previewMainText) { previewMainText.innerHTML = htmlContent; } /* adjustLayout(); */ });
         previewMainText.addEventListener('input', () => { const plainText = previewMainText.innerHTML.replace(/<br\s*\/?>/gi, '\n').replace(/<[^>]*>/g, ''); if (mainTextInput.value !== plainText) { mainTextInput.value = plainText; autoResizeTextarea(mainTextInput); } /* adjustLayout(); */ });
@@ -283,9 +313,9 @@
         textAlignGroup.addEventListener('click', (e) => { if (e.target.tagName === 'BUTTON') { const alignValue = e.target.dataset.align; mainTextBoxPreview.classList.remove('text-align-left', 'text-align-center', 'text-align-right'); mainTextBoxPreview.classList.add(`text-align-${alignValue}`); setActiveButton(textAlignGroup, alignValue, 'align'); } }); // Use mainTextBoxPreview ref
         fontSizeGroup.addEventListener('click', (e) => { if (e.target.tagName === 'BUTTON') { const sizeValue = e.target.dataset.size; mainTextBoxPreview.classList.remove('font-size-small', 'font-size-medium', 'font-size-large'); mainTextBoxPreview.classList.add(`font-size-${sizeValue}`); setActiveButton(fontSizeGroup, sizeValue, 'size'); } }); // Use mainTextBoxPreview ref
         templateSelect.addEventListener('change', () => { const selectedTemplateKey = templateSelect.value; const template = templates[selectedTemplateKey]; if (template) { cardTitleInput.value = template.title || ''; cardBgColorInput.value = template.bgColor || DEFAULT_BG_COLOR; cardTextColorInput.value = template.textColor || DEFAULT_TEXT_COLOR; cardSubtitleInput.value = template.subtitle || ''; mainTextInput.value = template.mainText || ''; notesTextInput.value = template.notes || ''; creatorNameInput.value = template.creator || ''; imageDataUrlInput.value = template.imageDataUrl || ''; const textAlign = template.textAlign || DEFAULT_TEXT_ALIGN; const fontSize = template.fontSize || DEFAULT_FONT_SIZE; mainTextBoxPreview.classList.remove('text-align-left', 'text-align-center', 'text-align-right'); mainTextBoxPreview.classList.add(`text-align-${textAlign}`); setActiveButton(textAlignGroup, textAlign, 'align'); mainTextBoxPreview.classList.remove('font-size-small', 'font-size-medium', 'font-size-large'); mainTextBoxPreview.classList.add(`font-size-${fontSize}`); setActiveButton(fontSizeGroup, fontSize, 'size'); updatePreviewFromInputs(); previewMainText.innerHTML = mainTextInput.value.replace(/\n/g, '<br>'); autoResizeTextarea(mainTextInput); templateSelect.value = ""; } });
-        saveButton.addEventListener('click', () => { try { const cardData = { title: cardTitleInput.value, bgColor: cardBgColorInput.value, textColor: cardTextColorInput.value, subtitle: cardSubtitleInput.value, mainText: mainTextInput.value, notes: notesTextInput.value, creator: creatorNameInput.value, imageDataUrl: imageDataUrlInput.value, textAlign: mainTextBoxPreview.classList.contains('text-align-center') ? 'center' : (mainTextBoxPreview.classList.contains('text-align-right') ? 'right' : 'left'), fontSize: mainTextBoxPreview.classList.contains('font-size-small') ? 'small' : (mainTextBoxPreview.classList.contains('font-size-large') ? 'large' : 'medium') }; localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(cardData)); displaySaveStatus('Card saved successfully!'); } catch (error) { console.error("Error saving card:", error); displaySaveStatus('Error saving card.', true); } }); // Use mainTextBoxPreview ref
-        loadButton.addEventListener('click', () => { const savedData = localStorage.getItem(LOCAL_STORAGE_KEY); if (savedData) { try { const cardData = JSON.parse(savedData); cardTitleInput.value = cardData.title || ''; cardBgColorInput.value = cardData.bgColor || DEFAULT_BG_COLOR; cardTextColorInput.value = cardData.textColor || DEFAULT_TEXT_COLOR; cardSubtitleInput.value = cardData.subtitle || ''; mainTextInput.value = cardData.mainText || ''; notesTextInput.value = cardData.notes || ''; creatorNameInput.value = cardData.creator || ''; imageDataUrlInput.value = cardData.imageDataUrl || ''; const textAlign = cardData.textAlign || DEFAULT_TEXT_ALIGN; const fontSize = cardData.fontSize || DEFAULT_FONT_SIZE; mainTextBoxPreview.classList.remove('text-align-left', 'text-align-center', 'text-align-right'); mainTextBoxPreview.classList.add(`text-align-${textAlign}`); setActiveButton(textAlignGroup, textAlign, 'align'); mainTextBoxPreview.classList.remove('font-size-small', 'font-size-medium', 'font-size-large'); mainTextBoxPreview.classList.add(`font-size-${fontSize}`); setActiveButton(fontSizeGroup, fontSize, 'size'); updatePreviewFromInputs(); previewMainText.innerHTML = mainTextInput.value.replace(/\n/g, '<br>'); autoResizeTextarea(mainTextInput); displaySaveStatus('Card loaded successfully!'); } catch (error) { console.error("Error loading card:", error); displaySaveStatus('Error loading card data.', true); } } else { displaySaveStatus('No saved card found.', true); } }); // Use mainTextBoxPreview ref
-        clearButton.addEventListener('click', () => { if (confirm('Are you sure you want to clear all fields?')) { cardTitleInput.value = ''; cardBgColorInput.value = DEFAULT_BG_COLOR; cardTextColorInput.value = DEFAULT_TEXT_COLOR; cardSubtitleInput.value = ''; mainTextInput.value = ''; notesTextInput.value = ''; creatorNameInput.value = ''; cardImageInput.value = ''; imageDataUrlInput.value = ''; mainTextBoxPreview.classList.remove('text-align-left', 'text-align-center', 'text-align-right'); mainTextBoxPreview.classList.add(`text-align-${DEFAULT_TEXT_ALIGN}`); setActiveButton(textAlignGroup, DEFAULT_TEXT_ALIGN, 'align'); mainTextBoxPreview.classList.remove('font-size-small', 'font-size-medium', 'font-size-large'); mainTextBoxPreview.classList.add(`font-size-${DEFAULT_FONT_SIZE}`); setActiveButton(fontSizeGroup, DEFAULT_FONT_SIZE, 'size'); updatePreviewFromInputs(); previewMainText.innerHTML = ''; autoResizeTextarea(mainTextInput); displaySaveStatus('Fields cleared.'); } }); // Use mainTextBoxPreview ref
+        saveButton.addEventListener('click', () => { try { const cardData = { title: cardTitleInput.value, bgColor: cardBgColorInput.value, textColor: cardTextColorInput.value, subtitle: cardSubtitleInput.value, mainText: mainTextInput.value, notes: notesTextInput.value, creator: creatorNameInput.value, linkUrl: linkUrlInput.value, imageDataUrl: imageDataUrlInput.value, textAlign: mainTextBoxPreview.classList.contains('text-align-center') ? 'center' : (mainTextBoxPreview.classList.contains('text-align-right') ? 'right' : 'left'), fontSize: mainTextBoxPreview.classList.contains('font-size-small') ? 'small' : (mainTextBoxPreview.classList.contains('font-size-large') ? 'large' : 'medium') }; localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(cardData)); displaySaveStatus('Card saved successfully!'); } catch (error) { console.error("Error saving card:", error); displaySaveStatus('Error saving card.', true); } }); // Use mainTextBoxPreview ref
+        loadButton.addEventListener('click', () => { const savedData = localStorage.getItem(LOCAL_STORAGE_KEY); if (savedData) { try { const cardData = JSON.parse(savedData); cardTitleInput.value = cardData.title || ''; cardBgColorInput.value = cardData.bgColor || DEFAULT_BG_COLOR; cardTextColorInput.value = cardData.textColor || DEFAULT_TEXT_COLOR; cardSubtitleInput.value = cardData.subtitle || ''; mainTextInput.value = cardData.mainText || ''; notesTextInput.value = cardData.notes || ''; creatorNameInput.value = cardData.creator || ''; linkUrlInput.value = cardData.linkUrl || ''; imageDataUrlInput.value = cardData.imageDataUrl || ''; const textAlign = cardData.textAlign || DEFAULT_TEXT_ALIGN; const fontSize = cardData.fontSize || DEFAULT_FONT_SIZE; mainTextBoxPreview.classList.remove('text-align-left', 'text-align-center', 'text-align-right'); mainTextBoxPreview.classList.add(`text-align-${textAlign}`); setActiveButton(textAlignGroup, textAlign, 'align'); mainTextBoxPreview.classList.remove('font-size-small', 'font-size-medium', 'font-size-large'); mainTextBoxPreview.classList.add(`font-size-${fontSize}`); setActiveButton(fontSizeGroup, fontSize, 'size'); updatePreviewFromInputs(); previewMainText.innerHTML = mainTextInput.value.replace(/\n/g, '<br>'); autoResizeTextarea(mainTextInput); displaySaveStatus('Card loaded successfully!'); } catch (error) { console.error("Error loading card:", error); displaySaveStatus('Error loading card data.', true); } } else { displaySaveStatus('No saved card found.', true); } }); // Use mainTextBoxPreview ref
+        clearButton.addEventListener('click', () => { if (confirm('Are you sure you want to clear all fields?')) { cardTitleInput.value = ''; cardBgColorInput.value = DEFAULT_BG_COLOR; cardTextColorInput.value = DEFAULT_TEXT_COLOR; cardSubtitleInput.value = ''; mainTextInput.value = ''; notesTextInput.value = ''; creatorNameInput.value = ''; linkUrlInput.value = ''; cardImageInput.value = ''; imageDataUrlInput.value = ''; mainTextBoxPreview.classList.remove('text-align-left', 'text-align-center', 'text-align-right'); mainTextBoxPreview.classList.add(`text-align-${DEFAULT_TEXT_ALIGN}`); setActiveButton(textAlignGroup, DEFAULT_TEXT_ALIGN, 'align'); mainTextBoxPreview.classList.remove('font-size-small', 'font-size-medium', 'font-size-large'); mainTextBoxPreview.classList.add(`font-size-${DEFAULT_FONT_SIZE}`); setActiveButton(fontSizeGroup, DEFAULT_FONT_SIZE, 'size'); updatePreviewFromInputs(); previewMainText.innerHTML = ''; autoResizeTextarea(mainTextInput); displaySaveStatus('Fields cleared.'); } }); // Use mainTextBoxPreview ref
         downloadButton.addEventListener('click', () => { const bgColorToUse = cardBgColorInput.value || '#ffffff'; html2canvas(cardPreview, { useCORS: true, logging: false, backgroundColor: bgColorToUse }).then(canvas => { const imageDataUrl = canvas.toDataURL('image/png'); const link = document.createElement('a'); const filename = (cardTitleInput.value || 'communication-card').replace(/[^a-z0-9]/gi, '_').toLowerCase() + '.png'; link.download = filename; link.href = imageDataUrl; document.body.appendChild(link); link.click(); document.body.removeChild(link); }).catch(err => { console.error("Error generating card image:", err); alert("Sorry, there was an error generating the card image."); }); });
 
         // --- Initial Setup ---


### PR DESCRIPTION
## Summary
- allow entering a link to embed as a QR code
- position small QR code at the bottom corner of the card
- store and load the link value along with other card data
- include QR code when clearing/initialising

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684d5f0084f0832da76c44404556d849